### PR TITLE
Bookworm compatibility

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 #=================================================
 
 # dependencies used by the app
-pkg_dependencies=""
+pkg_dependencies="php8.2-common"
 nodejs_version="14.19.3"
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -113,7 +113,7 @@ ynh_script_progression --message="Installing dependencies..." --weight=1
 ###		- As well as the section "REINSTALL DEPENDENCIES" in the restore script
 ###		- And the section "UPGRADE DEPENDENCIES" in the upgrade script
 
-#ynh_install_app_dependencies $pkg_dependencies
+ynh_install_app_dependencies $pkg_dependencies
 
 #=================================================
 # CREATE DEDICATED USER


### PR DESCRIPTION
 ## Problem

- `bookworm` build fails.

## Solution

- List PHP as dependency.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
